### PR TITLE
Uso de macro de tempo de compilação

### DIFF
--- a/arch/arch.asm
+++ b/arch/arch.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -137,7 +138,7 @@ arch:
                   db "Este utilitario nao aceita argumentos.", 10, 10
                   db "Exibe a arquitetura deste sistema e dispositivo.", 10, 10
                   db "arch versao ", versaoARCH, 10, 10
-                  db "Copyright (C) 2021-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2021-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .naoSuportado:    db 10, 10, "Arquitetura nao identificada.", 10, 0
 .i386:            db "i386", 0

--- a/atop/atop.asm
+++ b/atop/atop.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "Estelar/estelar.s"
 
 ;;************************************************************************************
@@ -397,7 +398,7 @@ atop:
                       db "Exibe os processos carregados na pilha de execucao do Hexagonix(R).", 10, 10 
                       db "Processos do Kernel sao filtrados e nao exibidos nesta lista.", 10, 10            
                       db "atop versao ", versaoATOP, 10, 10
-                      db "Copyright (C) 2020-2022 Felipe Miguel Nery Lunkes", 10
+                      db "Copyright (C) 2020-", __stringano, " Felipe Miguel Nery Lunkes", 10
                       db "Todos os direitos reservados.", 0
 .parametroAjuda:      db "?", 0  
 .parametroAjuda2:     db "--ajuda", 0

--- a/cat/cat.asm
+++ b/cat/cat.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -116,7 +117,7 @@ cat:
 .uso:             db 10, 10, "Uso: cat [arquivo]", 10, 10
                   db "Envia o conteudo de um arquivo para o console principal.", 10, 10
                   db "cat versao ", versaoCAT, 10, 10
-                  db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:  db "?", 0
 .parametroAjuda2: db "--ajuda", 0

--- a/clear/clear.asm
+++ b/clear/clear.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -119,7 +120,7 @@ clear:
 .uso:             db 10, 10, "Uso: clear", 10, 10
                   db "Limpa o conteudo do console principal (vd0) e de consoles virtuais.", 10, 10
                   db "clear versao ", versaoCLEAR, 10, 10
-                  db "Copyright (C) 2017-2021 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:  db "?", 0
 .parametroAjuda2: db "--ajuda", 0

--- a/cowsay/cowsay.asm
+++ b/cowsay/cowsay.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -386,7 +387,7 @@ cowsay:
                   db "Essa alteracao deve ser solicitada ANTES da mensagem.", 10
                   db 'Em caso de frase, o caractere " deve constar antes e depois da frase.', 10, 10
                   db "cowsay versao ", versaoCOWSAY, 10, 10
-                  db "Copyright (C) 2020-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2020-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:  db "?", 0
 .parametroAjuda2: db "--ajuda", 0

--- a/cp/cp.asm
+++ b/cp/cp.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -239,7 +240,7 @@ cp:
                     db "Realiza a copia de um arquivo fornecido em outro. Dois nomes de arquivo sao necessarios, sendo um", 10
                     db "de entrada e outro de saida.", 10, 10
                     db "cp versao ", versaoCP, 10, 10
-                    db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                    db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                     db "Todos os direitos reservados.", 10, 0
 .fonteIndisponivel: db 10, 10, "O arquivo fonte fornecido nao pode ser encontrado neste disco.", 10, 0                              
 .destinoExistente:  db 10, 10, "Ja existe um arquivo com o nome fornecido para o destino. Por favor, remova o arquivo com o mesmo", 10

--- a/date/date.asm
+++ b/date/date.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -340,7 +341,7 @@ date:
 .uso:             db 10, 10, "Uso: date", 10, 10
                   db "Exibe data e hora do sistema.", 10, 10
                   db "date versao ", versaoDATE, 10, 10
-                  db "Copyright (C) 2020-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2020-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .domingo:         db " (domingo)", 0
 .segunda:         db " (segunda-feira)", 0

--- a/echo/echo.asm
+++ b/echo/echo.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -102,7 +103,7 @@ echo:
 .uso:             db 10, 10, "Uso: echo [mensagem]", 10, 10
                   db "Envia o conteudo de uma mensagem para o console principal.", 10, 10
                   db "echo versao ", versaoECHO, 10, 10
-                  db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:  db "?", 0
 .parametroAjuda2: db "--ajuda", 0

--- a/energia/energia.asm
+++ b/energia/energia.asm
@@ -303,7 +303,7 @@ energia:
                      db "-d - Prepara e inicia o desligamento do computador.", 10
                      db "-r - Prepara e reinicia o computador.", 10, 10                                    
                      db "energia versao ", versaoENERGIA, 10, 10
-                     db "Copyright (C) 2022 Felipe Miguel Nery Lunkes", 10
+                     db "Copyright (C) 2022-", __stringano, " Felipe Miguel Nery Lunkes", 10
                      db "Todos os direitos reservados.", 10, 0
 
 energia.Verbose:

--- a/file/file.asm
+++ b/file/file.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -413,7 +414,7 @@ fileUnix:
 .uso:             db 10, 10, "Uso: file [arquivo]", 10, 10
                   db "Recupera as informacoes do arquivo e envia para o console principal.", 10, 10
                   db "file versao ", versaoFILE, 10, 10
-                  db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .arquivoInvalido: db 10, 10, "O nome de arquivo e invalido. Digite um nome de arquivo valido.", 10, 0
 .infoArquivo:     db 10, 10, "Nome do arquivo: ", 0

--- a/fnt/fnt.asm
+++ b/fnt/fnt.asm
@@ -46,7 +46,7 @@ fnt:
 .uso:             db 10, 10, "Uso: fnt [arquivo de fonte]", 10, 10
                   db "Solicita a alteracao da fonte grafica do sistema.", 10, 10
                   db "fnt versao ", versaoFNT, 10, 10
-                  db "Copyright (C) 2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2022-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .nomeArquivo:     db 10, 10, "Nome do arquivo de fonte: ", 0    
 .nomeFonte:       db "Nome do arquivo: ", 0

--- a/free/free.asm
+++ b/free/free.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -130,7 +131,7 @@ free:
 .uso:             db 10, 10, "Uso: free", 10, 10
                   db "Exibe informacoes sobre uso da memoria do sistema instalada.", 10, 10
                   db "free versao ", versaoFREE, 10, 10
-                  db "Copyright (C) 2020-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2020-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .memoria:         db "Memoria instalada | Memoria utilizada | Memoria reservada para o Hexagon", 10, 0
 .kbytes:          db " bytes           ", 0

--- a/hash/hash.asm
+++ b/hash/hash.asm
@@ -32,6 +32,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioShell, 01h
 
 include "hexagon.s"
 include "erros.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -449,7 +450,7 @@ hash:
 .uso:                  db 10, 10, "Uso: hash", 10, 10
                        db "Inicia um hashell Unix para o usuario atual.", 10, 10               
                        db "hash versao ", versaoHASH, 10, 10
-                       db "Copyright (C) 2020-2022 Felipe Miguel Nery Lunkes", 10
+                       db "Copyright (C) 2020-", __stringano, " Felipe Miguel Nery Lunkes", 10
                        db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:       db "?", 0   
 .parametroAjuda2:      db "--ajuda", 0   

--- a/hostname/hostname.asm
+++ b/hostname/hostname.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -129,7 +130,7 @@ hostname:
 .uso:             db 10, 10, "Uso: hostname", 10, 10
                   db "Exibe o nome de host definido para este dispositivo.", 10, 10
                   db "hostname versao ", versaoHOSTNAME, 10, 10
-                  db "Copyright (C) 2021-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2021-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:  db "?", 0
 .parametroAjuda2: db "--ajuda", 0

--- a/login/login.asm
+++ b/login/login.asm
@@ -800,7 +800,7 @@ login:
 .uso:              db 10, 10, "Uso: login [usuario]", 10, 10
                    db "Realiza login em um usuario cadastrado.", 10, 10               
                    db "login versao ", versaoLOGIN, 10, 10
-                   db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                   db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                    db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:   db "?", 0  
 .parametroAjuda2:  db "--ajuda", 0 

--- a/ls/ls.asm
+++ b/ls/ls.asm
@@ -33,6 +33,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 align 4
 
 include "hexagon.s"
+include "macros.s"
 include "Estelar/estelar.s"
 
 ;;************************************************************************************
@@ -642,7 +643,7 @@ ls:
                    db "Parametros disponiveis:", 10, 10
                    db "-a - Lista todos os arquivos disponiveis no volume.", 10, 10
                    db "ls versao ", versaoLS, 10, 10
-                   db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                   db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                    db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:   db "?", 0    
 .parametroAjuda2:  db "--ajuda", 0

--- a/lshapp/lshapp.asm
+++ b/lshapp/lshapp.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -377,7 +378,7 @@ lshapp:
 .uso:                 db 10, 10, "Uso: lshapp [arquivo]", 10, 10
                       db "Recupera as informacoes de uma imagem HAPP.", 10, 10
                       db "lshapp versao ", versaoLSHAPP, 10, 10
-                      db "Copyright (C) 2020-2022 Felipe Miguel Nery Lunkes", 10
+                      db "Copyright (C) 2020-", __stringano, " Felipe Miguel Nery Lunkes", 10
                       db "Todos os direitos reservados.", 10, 0
 .arquivoInvalido:     db 10, 10, "O nome de arquivo e invalido. Digite um nome de arquivo valido.", 10, 0
 .infoArquivo:         db 10, 10, "Nome do arquivo: ", 0

--- a/lshmod/lshmod.asm
+++ b/lshmod/lshmod.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 ;;
@@ -45,7 +46,7 @@ lshmod:
 .uso:                 db 10, 10, "Uso: lshmod [arquivo]", 10, 10
                       db "Recupera as informacoes de uma imagem ou modulo HBoot.", 10, 10
                       db "lshmod versao ", versaoLSHMOD, 10, 10
-                      db "Copyright (C) 2022 Felipe Miguel Nery Lunkes", 10
+                      db "Copyright (C) 2022-", __stringano, " Felipe Miguel Nery Lunkes", 10
                       db "Todos os direitos reservados.", 10, 0
 .arquivoInvalido:     db 10, 10, "O nome de arquivo e invalido. Digite um nome de arquivo valido.", 10, 0
 .infoArquivo:         db 10, 10, "Nome do arquivo: ", 0

--- a/man/man.asm
+++ b/man/man.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "Unix.s"
 
 ;;************************************************************************************
@@ -49,7 +50,7 @@ man:
                   db "Versao CoreUtils: ", versaoCoreUtils, 10
                   db "Versao UnixUtils: ", versaoUnixUtils, 10, 10                        
                   db "man versao ", versaoMAN, 10, 10
-                  db "Copyright (C) 2018-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2018-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .aguardar:        db "Pressione <q> para sair.", 0
 .naoEncontrado:   db ": manual nao encontrado para este utilitario.", 10, 0

--- a/mount/mount.asm
+++ b/mount/mount.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "erros.s"
 
 ;;************************************************************************************
@@ -320,7 +321,7 @@ mount:
                     db "Realiza a montagem de um volume em um ponto de montagem do sistema de arquivos.", 10, 10
                     db "Caso nenhum parametro seja fornecido, quaisquer montagens realizadas serao exibidas.", 10, 10
                     db "mount versao ", versaoMOUNT, 10, 10
-                    db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                    db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                     db "Todos os direitos reservados.", 10, 0
 .erroAbrindo:       db "Erro ao montar o volume no ponto de montagem especificado.", 10
                     db "Tente informar um nome valido ou referencia de um volume conectado.", 10, 0

--- a/ps/ps.asm
+++ b/ps/ps.asm
@@ -32,6 +32,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************
 
@@ -182,7 +183,7 @@ ps:
                    db "-v - Exibe apenas o uso de memoria dos processos em execucao.", 10, 10  
                    db "-o - Exibe o numero de processos na fila de execucao.", 10, 10            
                    db "ps versao ", versaoPS, 10, 10
-                   db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                   db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                    db "Todos os direitos reservados.", 0
 .parametroAjuda:   db "?", 0  
 .parametroAjuda2:  db "--ajuda", 0

--- a/rm/rm.asm
+++ b/rm/rm.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "erros.s"
 
 ;;************************************************************************************
@@ -192,7 +193,7 @@ rm:
 .uso:             db 10, 10, "Uso: rm [arquivo]", 10, 10
                   db "Solicita a exclusao de um arquivo no disco atual.", 10, 10
                   db "rm versao ", versaoRM, 10, 10
-                  db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                  db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                   db "Todos os direitos reservados.", 10, 0
 .confirmacao:     db "Voce tem certeza que deseja excluir este arquivo (s/N)? ", 0
 .deletado:        db 10, 10, "O arquivo solicitado foi deletado com sucesso.", 10, 0

--- a/sh/sh.asm
+++ b/sh/sh.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioShell, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "erros.s"
 
 ;;************************************************************************************
@@ -492,7 +493,7 @@ sh:
 .uso:                  db 10, 10, "Uso: sh", 10, 10
                        db "Inicia um shell Unix para o usuario atual.", 10, 10               
                        db "sh versao ", versaoSH, 10, 10
-                       db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                       db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                        db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:       db "?", 0   
 .parametroAjuda2:      db "--ajuda", 0

--- a/su/su.asm
+++ b/su/su.asm
@@ -46,6 +46,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, suAndromeda, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************          
 
@@ -693,7 +694,7 @@ su:
 .uso:               db 10, 10, "Uso: su [usuario]", 10, 10
                     db "Altera para um usuario cadastrado.", 10, 10               
                     db "su versao ", versaoSU, 10, 10
-                    db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                    db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                     db "Todos os direitos reservados.", 0
 .semArquivoUnix:    db 10, "O arquivo de configuracao do ambiente Unix de controle de contas nao foi encontrado.", 10, 0 
 .semUsuario:        db 10, "O usuario solicitado nao foi encontrado: ", 0              

--- a/syslogd/syslogd.asm
+++ b/syslogd/syslogd.asm
@@ -49,7 +49,7 @@ syslogd:
 .uso:              db 10, 10, "Uso: syslogd [mensagem]", 10, 10
                    db "Envia uma mensagem de componentes do Hexagonix e de utilitarios para o log do sistema.", 10, 10
                    db "syslogd versao ", versaoSYSLOGD, 10, 10
-                   db "Copyright (C) 2022 Felipe Miguel Nery Lunkes", 10
+                   db "Copyright (C) 2022-", __stringano, " Felipe Miguel Nery Lunkes", 10
                    db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:   db "?", 0
 .parametroAjuda2:  db "--ajuda", 0

--- a/top/top.asm
+++ b/top/top.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "Estelar/estelar.s"
 
 ;;************************************************************************************
@@ -209,7 +210,7 @@ top:
                       db "Exibe os processos carregados na pilha de execucao do Hexagonix(R).", 10, 10 
                       db "Processos do Kernel sao filtrados e nao exibidos nesta lista.", 10, 10            
                       db "top versao ", versaoTOP, 10, 10
-                      db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                      db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                       db "Todos os direitos reservados.", 0
 .parametroAjuda:      db "?", 0  
 .parametroAjuda2:     db "--ajuda", 0

--- a/uname/uname.asm
+++ b/uname/uname.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 include "verUtils.s"
     
 ;;************************************************************************************          
@@ -95,7 +96,7 @@ uname:
                             db " -i: Plataforma de hardware do sistema.", 10
                             db " -o: Nome do sistema operacional em execucao.", 10, 10                                
                             db "uname versao ", versaoUNAME, 10, 10
-                            db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                            db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                             db "Todos os direitos reservados.", 0
                             
 ponto: db ".", 0

--- a/whoami/whoami.asm
+++ b/whoami/whoami.asm
@@ -31,6 +31,7 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 ;;************************************************************************************
 
 include "hexagon.s"
+include "macros.s"
 
 ;;************************************************************************************          
 
@@ -144,7 +145,7 @@ whoami:
                    db "-t - Exibe todas as informacoes possiveis do usuario atualmente logado", 10
                    db "-u - Exibe apenas o nome do usuario logado", 10, 10             
                    db "whoami versao ", versaoWHOAMI, 10, 10
-                   db "Copyright (C) 2017-2022 Felipe Miguel Nery Lunkes", 10
+                   db "Copyright (C) 2017-", __stringano, " Felipe Miguel Nery Lunkes", 10
                    db "Todos os direitos reservados.", 10, 0
 .parametroAjuda:   db "?", 0  
 .parametroAjuda2:  db "--ajuda", 0 


### PR DESCRIPTION
- Novo macro que insere no código dados obtidos em tempo de compilação, especialmente datas para cálculo de build e ano de copyright dinâmico daquele executável. Isso torna o processo de alteração de ano de copyright automático, sem necessidade de edição manual.