### PR TITLE
Melhorias em logind e correção de inclusão de arquivo em man.asm

### DIFF
--- a/logind/logind.asm
+++ b/logind/logind.asm
@@ -127,7 +127,7 @@ match =Hexagonix, TIPOLOGIN
 }
 
 .versaoSistema:    db 10, "Hexagonix versao ", 0
-.tty0:             db 10, "Seja bem-vindo ao Hexagonix (vd0)", 0
+.console:          db " (vd0)", 0
 .semArquivoUnix:   db 10, 10, "O arquivo de configuracao do ambiente Unix de controle de contas nao foi encontrado.", 10, 0        
 .colcheteEsquerdo: db " [", 0
 .colcheteDireito:  db "]", 0
@@ -384,9 +384,7 @@ match =Moderno, TIPOLOGIN
 
 .continuar:
 
-    novaLinha
-
-    mov esi, logind.tty0
+    mov esi, logind.console
 
     imprimirString
 

--- a/man/man.asm
+++ b/man/man.asm
@@ -68,7 +68,6 @@ cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 
 include "hexagon.s"
 include "macros.s"
-include "Unix.s"
 
 ;;************************************************************************************
 


### PR DESCRIPTION
- Conformidade com mensagens de login do FreeBSD (logind);
-  Correção de inclusão de arquivo (Unix.s) em man.asm (o arquivo teve seu conteúdo movido para man.asm e foi removido).