### PR TITLE
HX-16-Alterar-versao-minima-requerida-de-utilitarios-para-Hexagon-v1.0.0

### DIFF
--- a/mv/mv.asm
+++ b/mv/mv.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Aqui está uma estrutura para o cabeçalho HAPP
 
 ;; Instância | Estrutura | Arquitetura | Versão | Subversão | Entrada | Tipo
-cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 5, inicioAPP, 01h
+cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 
 ;;************************************************************************************
 
@@ -244,7 +244,7 @@ usoAplicativo:
 ;;
 ;;************************************************************************************
 
-versaoMV equ "0.0.1"
+versaoMV equ "0.0.2"
 
 mv:
 

--- a/uname/uname.asm
+++ b/uname/uname.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Aqui está uma estrutura para o cabeçalho HAPP
 
 ;; Instância | Estrutura | Arquitetura | Versão | Subversão | Entrada | Tipo
-cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 5, inicioAPP, 01h
+cabecalhoAPP cabecalhoHAPP HAPP.Arquiteturas.i386, 1, 00, inicioAPP, 01h
 
 ;;************************************************************************************
 
@@ -83,7 +83,7 @@ include "macros.s"
 
 ;;************************************************************************************
 
-versaoUNAME equ "2.6.7.0"
+versaoUNAME equ "2.6.8.0"
 
 uname:
 


### PR DESCRIPTION
Alterada versão mínima do Hexagon necessária para a execução dos utilitários mv e uname, de acordo com a nova versão do Hexagon