### PR TITLE
New /shadow database and user management tools

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Hexagonix Operating System
 
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes<br>
+Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes<br>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/Unix.sh
+++ b/Unix.sh
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -166,7 +166,7 @@ function showVersion() {
 
 echo "hx build module for Unix utilities, version $UNIX_MOD_VERSION"
 echo
-echo -e "\e[0mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e "\e[0mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no warranty."
 
 }

--- a/adduser/adduser.asm
+++ b/adduser/adduser.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,7 @@
 ;;
 ;;                          adduser utility for Hexagonix
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                              All rights reserved.
 ;;
 ;;************************************************************************************

--- a/adduser/adduser.asm
+++ b/adduser/adduser.asm
@@ -1,0 +1,419 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
+;;************************************************************************************
+;;
+;;                          adduser utility for Hexagonix
+;;
+;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                              All rights reserved.
+;;
+;;************************************************************************************
+
+use32
+
+;; Now let's create a HAPP header for the application
+
+include "HAPP.s" ;; Here is a structure for the HAPP header
+
+;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
+appHeader headerHAPP HAPP.Architectures.i386, 1, 5, applicationStart, 01h
+
+;;************************************************************************************
+
+include "hexagon.s"
+include "console.s"
+include "macros.s"
+include "passwdHash.s"
+
+;;************************************************************************************
+
+applicationStart:
+
+    push ds ;; User mode data segment (38h selector)
+    pop es
+
+    hx.syscall hx.getUser
+
+    cmp eax, 777
+    je .isRoot
+
+    fputs adduser.permissionDenied
+
+    jmp finish
+
+.isRoot:
+
+    fputs adduser.promptUser
+
+    mov eax, 15
+
+    mov ebx, 1
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    cmp byte[esi], 0
+    je .noUsername
+
+    mov edi, newUser
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    mov esi, newUser
+
+    call Hexagon.LibASM.PasswdHash.findUser
+
+    jnc .alreadyExists
+
+    fputs adduser.promptPassword
+
+    mov eax, 64
+
+    mov ebx, 1234h ;; We don't want to echo the password!
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    mov edi, passwordFirst
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    fputs adduser.promptPasswordAgain
+
+    mov eax, 64
+
+    mov ebx, 1234h
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    mov edi, passwordFirst
+
+    hx.syscall hx.compareWordsString
+
+    jnc .passwordMismatch
+
+    mov esi, passwordFirst
+
+    call Hexagon.LibASM.PasswdHash.hash
+
+    fputs adduser.promptShell
+
+    mov eax, 11
+
+    mov ebx, 1
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    cmp byte[esi], 0
+    jne .shellGiven
+
+    mov esi, adduser.defaultShell
+
+.shellGiven:
+
+    mov edi, newShell
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    fputs adduser.promptTheme
+
+    mov eax, 7
+
+    mov ebx, 1
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    cmp byte[esi], 0
+    jne .themeGiven
+
+    mov esi, adduser.defaultTheme
+
+.themeGiven:
+
+    mov edi, newTheme
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    call appendUser
+
+    jc .writeError
+
+    fputs adduser.success
+
+    jmp finish
+
+.noUsername:
+
+    fputs adduser.withoutUsername
+
+    jmp finish
+
+.alreadyExists:
+
+    fputs adduser.userExists
+
+    jmp finish
+
+.passwordMismatch:
+
+    fputs adduser.passwordMismatch
+
+    jmp finish
+
+.writeError:
+
+    fputs adduser.writeError
+
+    jmp finish
+
+;;************************************************************************************
+
+;; Appends a new username:hash:555:shell:theme line to /shadow and writes the
+;; whole file back (hx.unlink then hx.create, see the plan's Decisions:
+;; hx.create's own overwrite behavior is never relied on)
+;;
+;; Input: newUser, Hexagon.LibASM.PasswdHash.hashBuffer, newShell, newTheme
+;; already filled in by the caller
+;;
+;; Output: CF set on write failure
+
+appendUser:
+
+    mov esi, Hexagon.LibASM.PasswdHash.file
+    mov edi, Hexagon.LibASM.PasswdHash.fileBuffer
+
+    hx.syscall hx.open
+
+    jc .empty
+
+    mov esi, Hexagon.LibASM.PasswdHash.fileBuffer
+
+    hx.syscall hx.stringSize
+
+    mov edi, Hexagon.LibASM.PasswdHash.fileBuffer
+
+    add edi, eax
+
+    cmp eax, 0
+    je .buildLine
+
+    mov esi, edi
+
+    dec esi ;; ESI -> last real byte of the existing content
+
+    cmp byte[esi], 10
+    je .buildLine ;; Already ends in a newline
+
+    mov byte[edi], 10 ;; Separator newline before the new record
+
+    inc edi
+
+    jmp .buildLine
+
+.empty:
+
+    mov edi, Hexagon.LibASM.PasswdHash.fileBuffer
+
+.buildLine:
+
+    mov esi, newUser
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, Hexagon.LibASM.PasswdHash.hashBuffer
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, adduser.defaultCode
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, newShell
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, newTheme
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], 10
+
+    inc edi
+
+    mov byte[edi], 0
+
+    mov esi, Hexagon.LibASM.PasswdHash.file
+
+    hx.syscall hx.unlink
+
+    mov esi, Hexagon.LibASM.PasswdHash.fileBuffer
+
+    hx.syscall hx.stringSize
+
+    mov esi, Hexagon.LibASM.PasswdHash.file
+    mov edi, Hexagon.LibASM.PasswdHash.fileBuffer
+
+    hx.syscall hx.create
+
+    ret
+
+;;************************************************************************************
+
+applicationUsage:
+
+    fputs adduser.use
+
+    jmp finish
+
+;;************************************************************************************
+
+finish:
+
+    hx.syscall hx.exit
+
+;;************************************************************************************
+
+;;************************************************************************************
+;;
+;;                        Application variables and data
+;;
+;;************************************************************************************
+
+VERSION equ "0.1.0"
+
+adduser:
+
+.use:
+db 10, "Usage: adduser", 10, 10
+db "Interactively creates a new Hexagonix user account.", 10, 10
+db "adduser version ", VERSION, 10, 10
+db "Copyright (C) 2015-", __stringYear, " Felipe Miguel Nery Lunkes", 10
+db "All rights reserved.", 0
+.permissionDenied:
+db 10, "Only an administrative (or root) user can complete this action.", 10
+db "Login in this user to perform the desired operation.", 0
+.promptUser:
+db 10, "Username: ", 0
+.promptPassword:
+db 10, "Password: ", 0
+.promptPasswordAgain:
+db 10, "Repeat password: ", 0
+.promptShell:
+db 10, "Shell [sh]: ", 0
+.promptTheme:
+db 10, "Theme (dark/light) [dark]: ", 0
+.withoutUsername:
+db 10, "A username is required.", 0
+.userExists:
+db 10, "That username already exists.", 0
+.passwordMismatch:
+db 10, "The passwords entered do not match.", 0
+.writeError:
+db 10, "Could not write /shadow. No user was created.", 0
+.success:
+db 10, "User created.", 0
+.defaultShell:
+db "sh", 0
+.defaultTheme:
+db "dark", 0
+.defaultCode:
+db "555", 0
+
+newUser:
+times 17 db 0
+passwordFirst:
+times 65 db 0
+newShell:
+times 12 db 0
+newTheme:
+times 8 db 0

--- a/arch/arch.asm
+++ b/arch/arch.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/cat/cat.asm
+++ b/cat/cat.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/clear/clear.asm
+++ b/clear/clear.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/clock/clock.asm
+++ b/clock/clock.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/cowsay/cowsay.asm
+++ b/cowsay/cowsay.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/cp/cp.asm
+++ b/cp/cp.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/date/date.asm
+++ b/date/date.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/deluser/deluser.asm
+++ b/deluser/deluser.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,7 @@
 ;;
 ;;                          deluser utility for Hexagonix
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                              All rights reserved.
 ;;
 ;;************************************************************************************

--- a/deluser/deluser.asm
+++ b/deluser/deluser.asm
@@ -1,0 +1,274 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
+;;************************************************************************************
+;;
+;;                          deluser utility for Hexagonix
+;;
+;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                              All rights reserved.
+;;
+;;************************************************************************************
+
+use32
+
+;; Now let's create a HAPP header for the application
+
+include "HAPP.s" ;; Here is a structure for the HAPP header
+
+;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
+appHeader headerHAPP HAPP.Architectures.i386, 1, 5, applicationStart, 01h
+
+;;************************************************************************************
+
+include "hexagon.s"
+include "console.s"
+include "macros.s"
+include "passwdHash.s"
+
+;;************************************************************************************
+
+applicationStart:
+
+    push ds ;; User mode data segment (38h selector)
+    pop es
+
+    mov [parameters], edi
+
+    mov esi, [parameters]
+
+    cmp byte[esi], 0
+    je withoutParameter
+
+    mov edi, deluser.helpParameter
+    mov esi, [parameters]
+
+    hx.syscall hx.compareWordsString
+
+    jc applicationUsage
+
+    mov edi, deluser.helpParameter2
+    mov esi, [parameters]
+
+    hx.syscall hx.compareWordsString
+
+    jc applicationUsage
+
+    hx.syscall hx.getUser
+
+    cmp eax, 777
+    je .isRoot
+
+    fputs deluser.permissionDenied
+
+    jmp finish
+
+.isRoot:
+
+    mov edi, deluser.rootUser
+    mov esi, [parameters]
+
+    hx.syscall hx.compareWordsString
+
+    jc .cannotRemoveRoot
+
+    mov esi, [parameters]
+
+    call Hexagon.LibASM.PasswdHash.findUser
+
+    jc .userNotFound
+
+    putNewLine
+
+    fputs deluser.confirmation
+
+.getConfirmationKeys:
+
+    hx.syscall hx.waitKeyboard
+
+    cmp al, 'y'
+    je .confirmed
+
+    cmp al, 'Y'
+    je .confirmed
+
+    cmp al, 'n'
+    je .cancelled
+
+    cmp al, 'N'
+    je .cancelled
+
+    jmp .getConfirmationKeys
+
+.confirmed:
+
+    hx.syscall hx.printCharacter
+
+    mov esi, [parameters]
+    mov edi, 0
+
+    call Hexagon.LibASM.PasswdHash.rewriteUser
+
+    jc .writeError
+
+    fputs deluser.success
+
+    jmp finish
+
+.cancelled:
+
+    hx.syscall hx.printCharacter
+
+    fputs deluser.cancel
+
+    jmp finish
+
+.cannotRemoveRoot:
+
+    fputs deluser.cannotRemoveRoot
+
+    jmp finish
+
+.userNotFound:
+
+    fputs deluser.userNotFound
+
+    jmp finish
+
+.writeError:
+
+    fputs deluser.writeError
+
+    jmp finish
+
+;;************************************************************************************
+
+applicationUsage:
+
+    fputs deluser.use
+
+    jmp finish
+
+;;************************************************************************************
+
+withoutParameter:
+
+    fputs deluser.withoutParameter
+
+    jmp finish
+
+;;************************************************************************************
+
+finish:
+
+    hx.syscall hx.exit
+
+;;************************************************************************************
+
+;;************************************************************************************
+;;
+;;                        Application variables and data
+;;
+;;************************************************************************************
+
+VERSION equ "0.1.0"
+
+deluser:
+
+.use:
+db 10, "Usage: deluser [user]", 10, 10
+db "Removes a user account.", 10, 10
+db "deluser version ", VERSION, 10, 10
+db "Copyright (C) 2015-", __stringYear, " Felipe Miguel Nery Lunkes", 10
+db "All rights reserved.", 0
+.permissionDenied:
+db 10, "Only an administrative (or root) user can complete this action.", 10
+db "Login in this user to perform the desired operation.", 0
+.cannotRemoveRoot:
+db 10, "The root user cannot be removed.", 0
+.userNotFound:
+db 10, "That user was not found.", 0
+.confirmation:
+db "Are you sure you want to delete this user (y/N)? ", 0
+.cancel:
+db 10, "The operation was aborted by the user.", 0
+.success:
+db 10, "User removed.", 0
+.writeError:
+db 10, "Could not write /shadow. No user was removed.", 0
+.withoutParameter:
+db 10, "A username is required.", 10
+db "Use 'deluser ?' for help with this utility.", 0
+.helpParameter:
+db "?", 0
+.helpParameter2:
+db "--help", 0
+.rootUser:
+db "root", 0
+
+parameters: dd ?

--- a/echo/echo.asm
+++ b/echo/echo.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/file/file.asm
+++ b/file/file.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/fnt/fnt.asm
+++ b/fnt/fnt.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/free/free.asm
+++ b/free/free.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/hash/hash.asm
+++ b/hash/hash.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/hostname/hostname.asm
+++ b/hostname/hostname.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/init/init.asm
+++ b/init/init.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/kill/kill.asm
+++ b/kill/kill.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/launcher/launcher.asm
+++ b/launcher/launcher.asm
@@ -1,3 +1,71 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
 ;; Temporary diagnostic app, not part of the distribution.
 ;; Spawns workera and workerb (non-blocking) and then loops printing its own
 ;; tick too, so the log shows three independent contexts (this process plus

--- a/login/login.asm
+++ b/login/login.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,7 @@
 ;;
 ;;                       Unix utility login for Hexagonix
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                              All rights reserved.
 ;;
 ;;************************************************************************************
@@ -82,7 +82,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 00, loginHexagonix, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 6, loginHexagonix, 01h
 
 ;;************************************************************************************
 
@@ -90,8 +90,8 @@ include "hexagon.s"
 include "console.s"
 include "macros.s"
 include "log.s"
-
-searchSizeLimit = 32768
+include "dev.s"
+include "passwdHash.s"
 
 ;;************************************************************************************
 
@@ -103,14 +103,12 @@ searchSizeLimit = 32768
 
 ;;************************************************************************************
 
-VERSION equ "5.0.0"
+VERSION equ "6.0.0"
 
 login:
 
 .defaultShell: ;; Name of the file containing the default Hexagonix shell
 db "sh", 0
-.file: ;; Login management filename
-db "passwd", 0
 .fileNotFound:
 db 10, 10, "The user database was not found on the volume.", 10, 0
 .requestUser:
@@ -127,12 +125,14 @@ db "All rights reserved.", 10, 0
 db "?", 0
 .helpParameter2:
 db "--help", 0
-.rootUser:
-db "root", 0
 .wrongData:
 db 10, "Login incorrect", 0
 .logind:
 db "logind", 0
+.lightTheme:
+db "light", 0
+.darkTheme:
+db "dark", 0
 
 ;; Verbose Messages
 
@@ -152,6 +152,8 @@ db "Login accepted.", 0
 db "Login attempt prevented by authentication failure.", 0
 .verboseLogout:
 db "Logout performed successfully.", 0
+.rootUser:
+db "root", 0
 
 ;; Buffers
 
@@ -163,15 +165,9 @@ wrong:
 db 0
 parameters: ;; If the application received any parameters
 db 0
-positionBX: ;; Marking the search position in the file content
-dw 0
 
 hexagonixShell: ;; Stores the name of the shell to be used
-times 11 db 0
-user: ;; Username obtained from the file
-times 15 db 0
-passwordObtained:;; Password obtained from the file
-times 64 db 0
+times 12 db 0
 requestedUser:
 times 17 db 0
 previousUser:
@@ -224,8 +220,6 @@ startProcessing:
 
     systemLog login.verboseFindFile, 0, Log.Priorities.p4
 
-    call clearUserVariables
-
     fputs login.requestUser
 
     mov eax, 15
@@ -238,11 +232,11 @@ startProcessing:
 
     mov [requestedUser], esi
 
-    call findUserName
+    mov esi, [requestedUser]
+
+    call Hexagon.LibASM.PasswdHash.findUser
 
     jc .withoutUser
-
-    call findUserPassword
 
     fputs login.requestPassword
 
@@ -261,7 +255,10 @@ startProcessing:
 
 .continueProcessing:
 
-    mov edi, passwordObtained
+    call Hexagon.LibASM.PasswdHash.hash ;; ESI still points at the trimmed, typed password
+
+    mov esi, Hexagon.LibASM.PasswdHash.hashBuffer
+    mov edi, Hexagon.LibASM.PasswdHash.hashFound
 
     hx.syscall hx.compareWordsString
 
@@ -286,7 +283,14 @@ startProcessing:
 
     call registerUser
 
-    call findUserShell
+match =Modern, LOGIN_STYLE
+{
+
+    call applyTheme
+
+}
+
+    call copyFoundShell
 
     hx.syscall hx.unlock
 
@@ -346,424 +350,167 @@ startProcessing:
 
 ;;************************************************************************************
 
-registerUser:
+;; Copies Hexagon.LibASM.PasswdHash.shellFound (the authenticated user's shell
+;; field) into hexagonixShell, the buffer .startShell/.tryDefaultShell already
+;; share. hexagonixShell starts zero-filled and login only ever does this copy
+;; once per run, so no explicit NUL padding is needed, same assumption
+;; getDefaultShell below already relies on
 
-    clc
+copyFoundShell:
 
-    mov esi, login.rootUser
-    mov edi, user
+    push es
+
+    push ds ;; User mode data segment (38h selector)
+    pop es
+
+    mov esi, Hexagon.LibASM.PasswdHash.shellFound
+
+    hx.syscall hx.stringSize
+
+    push eax
+
+    mov edi, hexagonixShell
+    mov esi, Hexagon.LibASM.PasswdHash.shellFound
+
+    pop ecx
+
+    rep movsb
+
+    pop es
+
+    ret
+
+;;************************************************************************************
+
+;; Colors the console to match the authenticated user's theme field. Checks
+;; tty0's actual current colors against the target theme's pair first, since
+;; the console may already be showing it (Apps/Unix/logind/logind.asm's
+;; verifyTheme paints its own fixed default before any user is known), and
+;; skips the repaint if so; whatever painted the console before is not
+;; assumed to be any particular theme
+
+applyTheme:
+
+    push es
+
+    push ds ;; User mode data segment (38h selector)
+    pop es
+
+    mov edi, Hexagon.LibASM.PasswdHash.themeFound
+    mov esi, login.lightTheme
 
     hx.syscall hx.compareWordsString
 
-    jc .root
+    jc .light
 
-    mov eax, 555 ;; Common user code
+    mov edi, Hexagon.LibASM.PasswdHash.themeFound
+    mov esi, login.darkTheme
 
-    jmp .register
+    hx.syscall hx.compareWordsString
 
-.root:
+    jc .dark
 
-    mov eax, 777 ;; Root user code
+    jmp .done ;; Unrecognized theme value, leave the colors as they are
 
-.register:
+.light:
 
-    mov esi, user
+    mov esi, Hexagon.LibASM.Dev.video.tty0
+
+    hx.syscall hx.open
+
+    hx.syscall hx.getColor ;; EAX = current font color, EBX = current background
+
+    cmp eax, PRETO
+    jne .lightApply
+
+    cmp ebx, BRANCO_ANDROMEDA
+    jne .lightApply
+
+    jmp .done ;; Console already matches light, nothing to repaint
+
+.lightApply:
+
+    mov esi, Hexagon.LibASM.Dev.video.tty1 ;; Open first virtual console
+
+    hx.syscall hx.open
+
+    mov eax, HEXAGONIX_CLASSICO_PRETO
+    mov ebx, HEXAGONIX_CLASSICO_BRANCO
+
+    hx.syscall hx.setColor
+
+    hx.syscall hx.clearConsole
+
+    mov esi, Hexagon.LibASM.Dev.video.tty0 ;; Reopens the standard console
+
+    hx.syscall hx.open
+
+    mov eax, PRETO
+    mov ebx, BRANCO_ANDROMEDA
+
+    hx.syscall hx.setColor
+
+    hx.syscall hx.clearConsole
+
+    jmp .done
+
+.dark:
+
+    mov esi, Hexagon.LibASM.Dev.video.tty0
+
+    hx.syscall hx.open
+
+    hx.syscall hx.getColor ;; EAX = current font color, EBX = current background
+
+    cmp eax, BRANCO_ANDROMEDA
+    jne .darkApply
+
+    cmp ebx, PRETO
+    jne .darkApply
+
+    jmp .done ;; Console already matches dark, nothing to repaint
+
+.darkApply:
+
+    mov esi, Hexagon.LibASM.Dev.video.tty1 ;; Open first virtual console
+
+    hx.syscall hx.open
+
+    mov eax, HEXAGONIX_BLOSSOM_AMARELO
+    mov ebx, HEXAGONIX_BLOSSOM_CINZA
+
+    hx.syscall hx.setColor
+
+    hx.syscall hx.clearConsole
+
+    mov esi, Hexagon.LibASM.Dev.video.tty0 ;; Reopens the standard console
+
+    hx.syscall hx.open
+
+    mov eax, BRANCO_ANDROMEDA
+    mov ebx, PRETO
+
+    hx.syscall hx.setColor
+
+    hx.syscall hx.clearConsole
+
+.done:
+
+    pop es
+
+    ret
+
+;;************************************************************************************
+
+registerUser:
+
+    mov eax, [Hexagon.LibASM.PasswdHash.codeFound]
+
+    mov esi, [requestedUser]
 
     hx.syscall hx.setUser
 
     ret
-
-;;************************************************************************************
-
-findUserName:
-
-    clc
-
-    pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, login.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .userFileNotFound
-
-    mov si, appFileBuffer ;; Points to the buffer with the file contents
-    mov bx, 0FFFFh ;; Starts at position -1, so you can find the delimiters
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[positionBX], bx
-
-    cmp bx, searchSizeLimit
-    je .invalidUserName ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '@'
-    jne .searchBetweenDelimiters ;; The initial delimiter has been found
-
-;; BX now points to the first character of the username retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, user ;; The username will be copied to ES:DI
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.getUserName:
-
-    inc bx
-
-    cmp bx, 17
-    je .invalidUserName ;; If username is greater than 15, it is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '|' ;; If another delimiter is found, the username was loaded successfully
-    je .userNameObtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .getUserName
-
-.userNameObtained:
-
-    mov edi, user
-    mov esi, [requestedUser]
-
-    hx.syscall hx.compareWordsString
-
-    jc .obtained
-
-    call clearVariable
-
-    mov word bx, [positionBX]
-
-    mov si, appFileBuffer
-
-    jmp .searchBetweenDelimiters
-
-.obtained:
-
-    pop es
-
-    popa
-
-    clc
-
-    ret
-
-.invalidUserName:
-
-    pop es
-
-    popa
-
-    mov byte[wrong], 1
-
-    clc
-
-    ret
-
-.userFileNotFound:
-
-    pop es
-
-    popa
-
-    fputs login.fileNotFound
-
-    jmp finish
-
-;;************************************************************************************
-
-clearVariable:
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, user
-
-    hx.syscall hx.stringSize
-
-    push eax
-
-    mov esi, 0
-
-    mov edi, user
-
-    pop ecx
-
-    rep movsb
-
-    pop es
-
-    ret
-
-;;************************************************************************************
-
-clearUserVariables:
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, user
-
-    hx.syscall hx.stringSize
-
-    push eax
-
-    mov esi, ' '
-
-    mov edi, user
-
-    pop ecx
-
-    rep movsb
-
-    mov esi, requestedUser
-
-    hx.syscall hx.stringSize
-
-    push eax
-
-    mov esi, ' '
-
-    mov edi, passwordObtained
-
-    pop ecx
-
-    rep movsb
-
-    mov esi, hexagonixShell
-
-    hx.syscall hx.stringSize
-
-    push eax
-
-    mov esi, " "
-
-    mov edi, hexagonixShell
-
-    pop ecx
-
-    rep movsb
-
-    pop es
-
-    ret
-
-;;************************************************************************************
-
-findUserPassword:
-
-    pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, login.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .userFileNotFound
-
-    mov si, appFileBuffer    ;; Points to the buffer with the file contents
-    mov bx, word [positionBX] ;; Continua de onde a opção anterior parou
-
-    dec bx
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[positionBX], bx
-
-    cmp bx, searchSizeLimit
-
-    je .invalidUserPassword ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '|'
-    jne .searchBetweenDelimiters ;; The initial delimiter has been found
-
-;; BX now points to the first character of the password retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, passwordObtained ;; The password will be copied to ES:DI
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.getUserPassword:
-
-    inc bx
-
-    cmp bx, 66
-    je .invalidUserPassword ;; If password greater than 66, it is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '&' ;; If another delimiter is found, the password has been loaded successfully
-    je .userPasswordObtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .getUserPassword
-
-.userPasswordObtained:
-
-    pop es
-
-    popa
-
-    ret
-
-.invalidUserPassword:
-
-    pop es
-
-    popa
-
-    mov byte[wrong], 1
-
-    clc
-
-    ret
-
-.userFileNotFound:
-
-    pop es
-
-    popa
-
-    fputs login.fileNotFound
-
-    jmp finish
-
-;;************************************************************************************
-
-findUserShell:
-
-    pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, login.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .configurationFileNotFound
-
-    mov si, appFileBuffer   ;; Points to the buffer with the file contents
-    mov bx, word[positionBX] ;; Continue where the previous option left off
-
-    dec bx
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[positionBX], bx
-
-    cmp bx, searchSizeLimit
-
-    je .configurationFileNotFound  ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '&'
-    jne .searchBetweenDelimiters ;; The initial limiter has been found
-
-;; BX now points to the first character of the shell name retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, hexagonixShell ;; The shell name will be copied to ES:DI: hexagonixShell
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.getShellName:
-
-    inc bx
-
-    cmp bx, 13
-    je .invalidShellName ;; If file name greater than 11, the name is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '#' ;; If another delimiter is found, the name was loaded successfully
-    je .shellNameObtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .getShellName
-
-.shellNameObtained:
-
-    pop es
-
-    popa
-
-    ret
-
-.invalidShellName:
-
-    pop es
-
-    popa
-
-    jmp getDefaultShell
-
-
-.configurationFileNotFound:
-
-    pop es
-
-    popa
-
-    jmp getDefaultShell
 
 ;;************************************************************************************
 
@@ -896,14 +643,10 @@ checkDatabase:
 
     clc
 
-    mov esi, login.file
+    mov esi, Hexagon.LibASM.PasswdHash.file
 
     hx.syscall hx.fileExists
 
     jc defaultLogin
 
     ret
-
-;;************************************************************************************
-
-appFileBuffer: ;; Location where the configuration file will be opened

--- a/login/login.asm
+++ b/login/login.asm
@@ -103,7 +103,7 @@ include "passwdHash.s"
 
 ;;************************************************************************************
 
-VERSION equ "6.0.0"
+VERSION equ "6.1.0"
 
 login:
 
@@ -157,14 +157,14 @@ db "root", 0
 
 ;; Buffers
 
-tryDefaultShell: ;; Signals an attempt to load the default shell
-db 0
-previousCode:
-dd 0
-wrong:
-db 0
-parameters: ;; If the application received any parameters
-db 0
+tryDefaultShell: db 0;; Signals an attempt to load the default shell
+previousCode:    dd 0
+wrong:           db 0
+;; Set when the typed username wasn't found, so the password
+;; prompt still runs and only .loginRefused reveals it, instead
+;; of leaking account existence through an early exit
+userMissing:     db 0
+
 
 hexagonixShell: ;; Stores the name of the shell to be used
 times 12 db 0
@@ -236,7 +236,17 @@ startProcessing:
 
     call Hexagon.LibASM.PasswdHash.findUser
 
-    jc .withoutUser
+    mov byte[userMissing], 0
+
+    jnc .askPassword
+
+    mov byte[userMissing], 1
+
+;; The password prompt runs the same either way. Exiting early here instead
+;; would let an attacker tell which usernames exist in /shadow just from
+;; whether the prompt appears at all
+
+.askPassword:
 
     fputs login.requestPassword
 
@@ -255,6 +265,15 @@ startProcessing:
 
 .continueProcessing:
 
+;; hashFound (and codeFound/shellFound/themeFound) are left over from the
+;; last username that was actually found, if any: Hexagon.LibASM.PasswdHash.findUser
+;; never clears them on a miss. Comparing against them here for a username
+;; that wasn't found would risk accepting a stale, unrelated hash, so this
+;; case is refused outright without even hashing the typed password
+
+    cmp byte[userMissing], 1
+    je .loginRefused
+
     call Hexagon.LibASM.PasswdHash.hash ;; ESI still points at the trimmed, typed password
 
     mov esi, Hexagon.LibASM.PasswdHash.hashBuffer
@@ -271,11 +290,6 @@ startProcessing:
     mov byte[wrong], 1
 
     jmp startProcessing.continueAfterLoginRefused
-
-.withoutUser:
-
-    cmp byte[parameters], 0
-    je finish
 
 .loginAccepted:
 

--- a/logind/logind.asm
+++ b/logind/logind.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -70,7 +70,7 @@
 ;;
 ;;                          Login daemon for Hexagonix
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                              All rights reserved.
 ;;
 ;;************************************************************************************
@@ -93,8 +93,7 @@ include "macros.s"
 include "log.s"
 include "dev.s"
 include "verUtils.s"
-
-searchSizeLimit = 32768
+include "passwdHash.s"
 
 ;;************************************************************************************
 ;;
@@ -104,7 +103,7 @@ searchSizeLimit = 32768
 
 ;;************************************************************************************
 
-VERSION equ "1.14.0"
+VERSION equ "2.0.0"
 
 logind:
 
@@ -136,35 +135,20 @@ match =Hexagonix, LOGIN_STYLE
 
 }
 
-.file: ;; Login configuration filename
-db "passwd", 0
-.positionBX: ;; Marking the search position in the file content
-dw 0
 .systemVersion:
 db 10, "Hexagonix ", 0
 .console:
 db " (tty0)", 0
-.fileNotFound:
-db 10, 10, "The user database was not found on the volume.", 10, 0
 .leftBracket:
 db " [", 0
 .rightBracket:
 db "]", 0
-.lightTheme:
-db "light", 0
-.darkTheme:
-db "dark", 0
 .unknownVersion:
 db "[unknown]", 0
 .verboseLogind:
 db "logind version ", VERSION, ".", 0
 .OOBE:
 db "oobe", 0
-
-;; Buffers
-
-themeChosen: ;; Buffer for user-defined theme
-times 7 db 0
 
 ;;************************************************************************************
 
@@ -233,123 +217,16 @@ match =Modern, LOGIN_STYLE
 
 ;;************************************************************************************
 
+;; Colors the login screen itself, before any user is known. Theme is a
+;; per-user /shadow field now (see Apps/Unix/login/login.asm's applyTheme),
+;; which only exists once a user has actually authenticated. logind is a
+;; one-shot daemon that exits before that ever happens, so there is no user
+;; to look up here; this just applies a fixed default so the login prompt
+;; still has a consistent, deliberate appearance
+
 verifyTheme:
 
     pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, logind.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .fileNotFound
-
-    mov si, appFileBuffer ;; Points to the buffer with the file contents
-    mov bx, 0FFFFh ;; Starts at position -1, so you can find the delimiters
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[logind.positionBX], bx
-
-    cmp bx, searchSizeLimit
-    je .invalidThemeName ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '<'
-    jne .searchBetweenDelimiters ;; The initial limiter has been found
-
-;; BX now points to the first character of the username retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, themeChosen ;; The theme will be copied to ES:DI
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.getTheme:
-
-    inc bx
-
-    cmp bx, 7
-    je .invalidThemeName ;; If username is greater than 7, it is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '>' ;; If another delimiter is found, the username was loaded successfully
-    je .themeObtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .getTheme
-
-.themeObtained:
-
-    mov edi, themeChosen
-    mov esi, logind.lightTheme
-
-    hx.syscall hx.compareWordsString
-
-    jc .selectLightTheme
-
-    mov edi, themeChosen
-    mov esi, logind.darkTheme
-
-    hx.syscall hx.compareWordsString
-
-    jc .selectDarkTheme
-
-    mov word bx, [logind.positionBX]
-
-    mov si, appFileBuffer
-
-    jmp .searchBetweenDelimiters
-
-.selectLightTheme:
-
-    pop es
-
-    popa
-
-    mov esi, Hexagon.LibASM.Dev.video.tty1 ;; Open first virtual console
-
-    hx.syscall hx.open ;; Open the device
-
-    mov eax, HEXAGONIX_CLASSICO_PRETO
-    mov ebx, HEXAGONIX_CLASSICO_BRANCO
-
-    hx.syscall hx.setColor
-
-    hx.syscall hx.clearConsole ;; Clean the console
-
-    mov esi, Hexagon.LibASM.Dev.video.tty0 ;; Reopens the standard console
-
-    hx.syscall hx.open ;; Open the device
-
-    mov eax, PRETO
-    mov ebx, BRANCO_ANDROMEDA
-
-    hx.syscall hx.setColor
-
-    hx.syscall hx.clearConsole ;; Clean the console
-
-    ret
-
-.selectDarkTheme:
 
     mov esi, Hexagon.LibASM.Dev.video.tty1 ;; Open first virtual console
 
@@ -373,23 +250,9 @@ verifyTheme:
 
     hx.syscall hx.clearConsole ;; Clean the console
 
-.invalidThemeName:
-
-    pop es
-
     popa
 
     ret
-
-.fileNotFound:
-
-    pop es
-
-    popa
-
-    fputs logind.fileNotFound
-
-    jmp finish
 
 ;;************************************************************************************
 
@@ -445,7 +308,7 @@ checkDatabase:
 
     clc
 
-    mov esi, logind.file
+    mov esi, Hexagon.LibASM.PasswdHash.file
 
     hx.syscall hx.fileExists
 
@@ -453,4 +316,4 @@ checkDatabase:
 
 ;;************************************************************************************
 
-appFileBuffer: ;; Location where the configuration file will be opened
+appFileBuffer: ;; Scratch buffer verUtils.s's getHexagonixVersion reads into

--- a/ls/ls.asm
+++ b/ls/ls.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -276,10 +276,6 @@ list:
 
     call setFileColor
 
-    fputs [currentFile]
-
-    call setDefaultColor
-
     jmp .continue
 
 .application:
@@ -289,10 +285,6 @@ list:
     mov eax, VERDE_FLORESTA
 
     call setFileColor
-
-    fputs [currentFile]
-
-    call setDefaultColor
 
     jmp .continue
 
@@ -304,10 +296,6 @@ list:
 
     call setFileColor
 
-    fputs [currentFile]
-
-    call setDefaultColor
-
     jmp .continue
 
 .fileASM:
@@ -317,10 +305,6 @@ list:
     mov eax, VERMELHO
 
     call setFileColor
-
-    fputs [currentFile]
-
-    call setDefaultColor
 
     jmp .continue
 
@@ -332,10 +316,6 @@ list:
 
     call setFileColor
 
-    fputs [currentFile]
-
-    call setDefaultColor
-
     jmp .continue
 
 .fileUNX:
@@ -345,10 +325,6 @@ list:
     mov eax, MARROM_PERU
 
     call setFileColor
-
-    fputs [currentFile]
-
-    call setDefaultColor
 
     jmp .continue
 
@@ -369,10 +345,6 @@ list:
 
     call setFileColor
 
-    fputs [currentFile]
-
-    call setDefaultColor
-
     jmp .continue
 
 .fileCOW: ;; It must not be displayed
@@ -385,10 +357,6 @@ list:
     mov eax, HEXAGONIX_BLOSSOM_VERDE
 
     call setFileColor
-
-    fputs [currentFile]
-
-    call setDefaultColor
 
     jmp .continue
 
@@ -403,10 +371,6 @@ list:
 
     call setFileColor
 
-    fputs [currentFile]
-
-    call setDefaultColor
-
     jmp .continue
 
 .fileFNT:
@@ -419,10 +383,6 @@ list:
     mov eax, HEXAGONIX_BLOSSOM_AZUL_PO
 
     call setFileColor
-
-    fputs [currentFile]
-
-    call setDefaultColor
 
     jmp .continue
 
@@ -440,13 +400,28 @@ list:
 
     call setFileColor
 
-    fputs [currentFile]
-
-    call setDefaultColor
-
     jmp .continue
 
 .continue:
+
+;; A file that will really be shown is about to be printed here. Any new
+;; line requested by a previous, now-full row is only flushed at this
+;; point, so a row that ends up with nothing displayable on it (for
+;; example, one made up entirely of hidden files skipped further up) never
+;; gets a blank line of its own
+
+    cmp byte[ls.pendingNewLine], 0
+    je .noPendingNewLine
+
+    mov byte[ls.pendingNewLine], 0
+
+    putNewLine
+
+.noPendingNewLine:
+
+    fputs [currentFile]
+
+    call setDefaultColor
 
     call putSpace
 
@@ -474,9 +449,7 @@ list:
 
     add ecx, 1
 
-;; Continue
-
-    putNewLine
+    mov byte[ls.pendingNewLine], 1
 
     jmp .loopFiles
 
@@ -663,7 +636,7 @@ checkFile:
 ;;
 ;;************************************************************************************
 
-VERSION equ "4.0.1"
+VERSION equ "4.1.0"
 
 ls:
 
@@ -704,6 +677,8 @@ db "--help", 0
 .parameterAllFiles:
 db "-a" ,0
 .listAll:
+db 0
+.pendingNewLine:
 db 0
 .fontColor:
 dd 0

--- a/lshapp/lshapp.asm
+++ b/lshapp/lshapp.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/lshmod/lshmod.asm
+++ b/lshmod/lshmod.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/man/man.asm
+++ b/man/man.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/man/man.asm
+++ b/man/man.asm
@@ -83,10 +83,10 @@ include "macros.s"
 
 ;;************************************************************************************
 
-VERSION equ "3.0.1"
+VERSION equ "3.0.2"
 
-CoreUtilsVersion equ "Dormin-1.0"
-UnixUtilsVersion equ "Dormin-1.0"
+CoreUtilsVersion equ "Dormin-1.1"
+UnixUtilsVersion equ "Dormin-1.1"
 
 manBarColor     = AZUL_CALMANTE
 manBarFontColor = HEXAGONIX_CLASSICO_BRANCO

--- a/mount/mount.asm
+++ b/mount/mount.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/mv/mv.asm
+++ b/mv/mv.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/passwd/passwd.asm
+++ b/passwd/passwd.asm
@@ -1,0 +1,364 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
+;;************************************************************************************
+;;
+;;                          passwd utility for Hexagonix
+;;
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                              All rights reserved.
+;;
+;;************************************************************************************
+
+use32
+
+;; Now let's create a HAPP header for the application
+
+include "HAPP.s" ;; Here is a structure for the HAPP header
+
+;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
+appHeader headerHAPP HAPP.Architectures.i386, 1, 5, applicationStart, 01h
+
+;;************************************************************************************
+
+include "hexagon.s"
+include "console.s"
+include "macros.s"
+include "passwdHash.s"
+
+;;************************************************************************************
+
+applicationStart:
+
+    push ds ;; User mode data segment (38h selector)
+    pop es
+
+    mov [parameters], edi
+
+    mov edi, passwd.helpParameter
+    mov esi, [parameters]
+
+    hx.syscall hx.compareWordsString
+
+    jc applicationUsage
+
+    mov edi, passwd.helpParameter2
+    mov esi, [parameters]
+
+    hx.syscall hx.compareWordsString
+
+    jc applicationUsage
+
+    mov esi, [parameters]
+
+    cmp byte[esi], 0
+    je .ownPassword
+
+;; A username argument was given, only root may do this without knowing
+;; the target's current password
+
+    hx.syscall hx.getUser
+
+    cmp eax, 777
+    je .targetGiven
+
+    fputs passwd.permissionDenied
+
+    jmp finish
+
+.targetGiven:
+
+    mov esi, [parameters]
+    mov edi, targetUser
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    mov esi, targetUser
+
+    call Hexagon.LibASM.PasswdHash.findUser
+
+    jc .userNotFound
+
+    jmp .newPassword
+
+.ownPassword:
+
+    hx.syscall hx.getUser ;; ESI = own username
+
+    mov edi, targetUser
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    mov esi, targetUser
+
+    call Hexagon.LibASM.PasswdHash.findUser
+
+    jc .userNotFound
+
+    fputs passwd.promptCurrent
+
+    mov eax, 64
+
+    mov ebx, 1234h ;; We don't want to echo the password!
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    call Hexagon.LibASM.PasswdHash.hash
+
+    mov esi, Hexagon.LibASM.PasswdHash.hashBuffer
+    mov edi, Hexagon.LibASM.PasswdHash.hashFound
+
+    hx.syscall hx.compareWordsString
+
+    jnc .wrongCurrent
+
+.newPassword:
+
+    fputs passwd.promptNew
+
+    mov eax, 64
+
+    mov ebx, 1234h
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    mov edi, newPasswordFirst
+
+    call Hexagon.LibASM.PasswdHash.copyString
+
+    putNewLine
+
+    fputs passwd.promptNewAgain
+
+    mov eax, 64
+
+    mov ebx, 1234h
+
+    hx.syscall hx.getString
+
+    hx.syscall hx.trimString
+
+    mov edi, newPasswordFirst
+
+    hx.syscall hx.compareWordsString
+
+    jnc .mismatch
+
+    mov esi, newPasswordFirst
+
+    call Hexagon.LibASM.PasswdHash.hash
+
+;; Build the replacement line: username:newhash:code:shell:theme, reusing
+;; the code/shell/theme fields Hexagon.LibASM.PasswdHash.findUser already
+;; resolved for targetUser, only the hash field actually changes
+
+    mov edi, replacementLine
+
+    mov esi, targetUser
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, Hexagon.LibASM.PasswdHash.hashBuffer
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov eax, [Hexagon.LibASM.PasswdHash.codeFound]
+
+    hx.syscall hx.toString
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, Hexagon.LibASM.PasswdHash.shellFound
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], ':'
+
+    inc edi
+
+    mov esi, Hexagon.LibASM.PasswdHash.themeFound
+
+    call Hexagon.LibASM.PasswdHash.appendString
+
+    mov byte[edi], 0
+
+    mov esi, targetUser
+    mov edi, replacementLine
+
+    call Hexagon.LibASM.PasswdHash.rewriteUser
+
+    jc .writeError
+
+    fputs passwd.success
+
+    jmp finish
+
+.userNotFound:
+
+    fputs passwd.userNotFound
+
+    jmp finish
+
+.wrongCurrent:
+
+    fputs passwd.wrongCurrent
+
+    jmp finish
+
+.mismatch:
+
+    fputs passwd.mismatch
+
+    jmp finish
+
+.writeError:
+
+    fputs passwd.writeError
+
+    jmp finish
+
+;;************************************************************************************
+
+applicationUsage:
+
+    fputs passwd.use
+
+    jmp finish
+
+;;************************************************************************************
+
+finish:
+
+    hx.syscall hx.exit
+
+;;************************************************************************************
+
+;;************************************************************************************
+;;
+;;                        Application variables and data
+;;
+;;************************************************************************************
+
+VERSION equ "0.1.0"
+
+passwd:
+
+.use:
+db 10, "Usage: passwd [user]", 10, 10
+db "With no argument, changes your own password (your current password is", 10
+db "required). Root can pass a username to change someone else's password", 10
+db "without knowing their current one.", 10, 10
+db "passwd version ", VERSION, 10, 10
+db "Copyright (C) 2017-", __stringYear, " Felipe Miguel Nery Lunkes", 10
+db "All rights reserved.", 0
+.permissionDenied:
+db 10, "Only an administrative (or root) user can change another user's password.", 0
+.userNotFound:
+db 10, "That user was not found.", 0
+.promptCurrent:
+db 10, "Current password: ", 0
+.wrongCurrent:
+db 10, "Wrong current password.", 0
+.promptNew:
+db 10, "New password: ", 0
+.promptNewAgain:
+db 10, "Repeat new password: ", 0
+.mismatch:
+db 10, "The passwords entered do not match.", 0
+.writeError:
+db 10, "Could not write /shadow. The password was not changed.", 0
+.success:
+db 10, "Password changed.", 0
+.helpParameter:
+db "?", 0
+.helpParameter2:
+db "--help", 0
+
+parameters: dd ?
+targetUser:
+times 17 db 0
+newPasswordFirst:
+times 65 db 0
+replacementLine:
+times 96 db 0

--- a/passwd/passwd.asm
+++ b/passwd/passwd.asm
@@ -318,14 +318,14 @@ finish:
 ;;
 ;;************************************************************************************
 
-VERSION equ "0.1.1"
+VERSION equ "0.1.2"
 
 passwd:
 
 .use:
 db 10, "Usage: passwd [user]", 10, 10
 db "With no argument, changes your own password (your current password is", 10
-db "required). Root can pass a username to change someone else's password", 10
+db "required). root user can pass a username to change someone else's password", 10
 db "without knowing their current one.", 10, 10
 db "passwd version ", VERSION, 10, 10
 db "Copyright (C) 2017-", __stringYear, " Felipe Miguel Nery Lunkes", 10

--- a/passwd/passwd.asm
+++ b/passwd/passwd.asm
@@ -195,8 +195,6 @@ applicationStart:
 
     call Hexagon.LibASM.PasswdHash.copyString
 
-    putNewLine
-
     fputs passwd.promptNewAgain
 
     mov eax, 64
@@ -320,7 +318,7 @@ finish:
 ;;
 ;;************************************************************************************
 
-VERSION equ "0.1.0"
+VERSION equ "0.1.1"
 
 passwd:
 

--- a/ps/ps.asm
+++ b/ps/ps.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/ps/ps.asm
+++ b/ps/ps.asm
@@ -224,7 +224,7 @@ putSpace:
 
 ;;************************************************************************************
 
-;; Prints the status text for a process at a fixed column
+;; Prints the state text for a process at a fixed column
 ;;
 ;; Input:
 ;;
@@ -255,37 +255,46 @@ putStatus:
     cmp al, 5
     je .sleeping
 
-    fputs ps.statusUnknown
+    cmp al, 6
+    je .idle
+
+    fputs ps.stateUnknown
 
     ret
 
 .ready:
 
-    fputs ps.statusReady
+    fputs ps.stateReady
 
     ret
 
 .running:
 
-    fputs ps.statusRunning
+    fputs ps.stateRunning
 
     ret
 
 .blocked:
 
-    fputs ps.statusBlocked
+    fputs ps.stateBlocked
 
     ret
 
 .zombie:
 
-    fputs ps.statusZombie
+    fputs ps.stateZombie
 
     ret
 
 .sleeping:
 
-    fputs ps.statusSleeping
+    fputs ps.stateSleeping
+
+    ret
+
+.idle:
+
+    fputs ps.stateIdle
 
     ret
 
@@ -319,7 +328,7 @@ putParent:
 
 .kernel:
 
-    fputs ps.statusKernel
+    fputs ps.stateKernel
 
     ret
 
@@ -357,7 +366,7 @@ parameterOtherProcesses:
 
 ;;************************************************************************************
 
-VERSION equ "3.2.0"
+VERSION equ "3.3.0"
 
 ps:
 
@@ -391,19 +400,21 @@ db "-m", 0
 db "There are currently ", 0
 .processes:
 db " processes running.", 0
-.statusReady:
+.stateReady:
 db "READY", 0
-.statusRunning:
+.stateRunning:
 db "RUNNING", 0
-.statusBlocked:
+.stateBlocked:
 db "BLOCKED", 0
-.statusZombie:
+.stateZombie:
 db "ZOMBIE", 0
-.statusSleeping:
+.stateSleeping:
 db "SLEEPING", 0
-.statusUnknown:
+.stateIdle:
+db "IDLE", 0
+.stateUnknown:
 db "UNKNOWN", 0
-.statusKernel:
+.stateKernel:
 db "KERNEL", 0
 .positionY: db 0
 

--- a/ps/ps.asm
+++ b/ps/ps.asm
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 4, applicationStart, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 6, applicationStart, 01h
 
 ;;************************************************************************************
 
@@ -252,6 +252,9 @@ putStatus:
     cmp al, 4
     je .zombie
 
+    cmp al, 5
+    je .sleeping
+
     fputs ps.statusUnknown
 
     ret
@@ -277,6 +280,12 @@ putStatus:
 .zombie:
 
     fputs ps.statusZombie
+
+    ret
+
+.sleeping:
+
+    fputs ps.statusSleeping
 
     ret
 
@@ -348,7 +357,7 @@ parameterOtherProcesses:
 
 ;;************************************************************************************
 
-VERSION equ "3.1.0"
+VERSION equ "3.2.0"
 
 ps:
 
@@ -390,6 +399,8 @@ db "RUNNING", 0
 db "BLOCKED", 0
 .statusZombie:
 db "ZOMBIE", 0
+.statusSleeping:
+db "SLEEPING", 0
 .statusUnknown:
 db "UNKNOWN", 0
 .statusKernel:

--- a/rm/rm.asm
+++ b/rm/rm.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/sh/sh.asm
+++ b/sh/sh.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/shutdown/shutdown.asm
+++ b/shutdown/shutdown.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/su/su.asm
+++ b/su/su.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -79,24 +79,23 @@
 ;;
 ;; Pay attention to possible changes in the structure of the file used by login.
 ;;
-;; The Unix su utility uses the same 'passwd' file as login.
+;; The Unix su utility uses the same '/shadow' database as login.
 
 use32
-
-searchSizeLimit = 12288
 
 ;; Now let's create a HAPP header for the application
 
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 00, suHexagonix, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 6, suHexagonix, 01h
 
 ;;************************************************************************************
 
 include "hexagon.s"
 include "console.s"
 include "macros.s"
+include "passwdHash.s"
 
 ;;************************************************************************************
 
@@ -131,11 +130,11 @@ startProcessing:
 
     clc
 
-    call findUserName
+    mov esi, [userRequested]
+
+    call Hexagon.LibASM.PasswdHash.findUser
 
     jc .withoutUser
-
-    call findUserPassword
 
     fputs su.solicitarSenha
 
@@ -147,7 +146,10 @@ startProcessing:
 
     hx.syscall hx.trimString
 
-    mov edi, passwordObtained
+    call Hexagon.LibASM.PasswdHash.hash ;; ESI still points at the trimmed, typed password
+
+    mov esi, Hexagon.LibASM.PasswdHash.hashBuffer
+    mov edi, Hexagon.LibASM.PasswdHash.hashFound
 
     hx.syscall hx.compareWordsString
 
@@ -157,6 +159,10 @@ startProcessing:
 
 .withoutUser:
 
+    fputs su.withoutUser
+
+    fputs [userRequested]
+
     cmp byte[parameters], 0
     je finish
 
@@ -164,7 +170,7 @@ startProcessing:
 
     call registerUser
 
-    call findShell
+    call copyFoundShell
 
     call checkUser
 
@@ -216,14 +222,21 @@ startProcessing:
 
 ;;************************************************************************************
 
+;; CF set if the authenticated user's code is root (777), used to show the
+;; "great powers" warning before starting the shell
+
 checkUser:
+
+    cmp dword[Hexagon.LibASM.PasswdHash.codeFound], 777
+    je .isRoot
 
     clc
 
-    mov esi, su.rootUser
-    mov edi, user
+    ret
 
-    hx.syscall hx.compareWordsString
+.isRoot:
+
+    stc
 
     ret
 
@@ -231,26 +244,9 @@ checkUser:
 
 registerUser:
 
-    clc
+    mov eax, [Hexagon.LibASM.PasswdHash.codeFound]
 
-    mov esi, su.rootUser
-    mov edi, user
-
-    hx.syscall hx.compareWordsString
-
-    jc .root
-
-    mov eax, 555 ;; Common user code
-
-    jmp .register
-
-.root:
-
-    mov eax, 777 ;; Root user code
-
-.register:
-
-    mov esi, user
+    mov esi, [userRequested]
 
     hx.syscall hx.setUser
 
@@ -258,139 +254,27 @@ registerUser:
 
 ;;************************************************************************************
 
-findUserName:
+;; Copies Hexagon.LibASM.PasswdHash.shellFound (the authenticated user's shell
+;; field) into shellHexagonix, the buffer .loadShell/.tryDefaultShell already
+;; share. shellHexagonix starts zero-filled and su only ever does this copy
+;; once per run, so no explicit NUL padding is needed, same assumption
+;; getDefaultShell below already relies on
 
-    pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, su.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .fileNotFound
-
-    mov si, appFileBuffer ;; Points to the buffer with the file contents
-    mov bx, 0FFFFh ;; Starts at position -1, so you can find the delimiters
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[positionBX], bx
-
-    cmp bx, searchSizeLimit
-    je .invalidUsername ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '@'
-    jne .searchBetweenDelimiters ;; The starting delimiter was found
-
-;; BX now points to the first character of the username retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, user ;; The username will be copied to ES:DI
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.getUsername:
-
-    inc bx
-
-    cmp bx, 17
-    je .invalidUsername ;; If username is greater than 15, it is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '|' ;; If another delimiter is found, the username was loaded successfully
-    je .usernameObtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .getUsername
-
-.usernameObtained:
-
-    mov edi, user
-    mov esi, [userRequested]
-
-    hx.syscall hx.compareWordsString
-
-    jc .obtained
-
-    call clearVariables
-
-    mov word bx, [positionBX]
-
-    mov si, appFileBuffer
-
-    jmp .searchBetweenDelimiters
-
-.obtained:
-
-    pop es
-
-    popa
-
-    clc
-
-    ret
-
-.invalidUsername:
-
-    pop es
-
-    popa
-
-    fputs su.withoutUser
-
-    fputs [userRequested]
-
-    stc
-
-    ret
-
-.fileNotFound:
-
-    pop es
-
-    popa
-
-    fputs su.fileNotFound
-
-    jmp finish
-
-;;************************************************************************************
-
-clearVariables:
+copyFoundShell:
 
     push es
 
     push ds ;; User mode data segment (38h selector)
     pop es
 
-    mov esi, user
+    mov esi, Hexagon.LibASM.PasswdHash.shellFound
 
     hx.syscall hx.stringSize
 
     push eax
 
-    mov esi, 0
-
-    mov edi, user
+    mov edi, shellHexagonix
+    mov esi, Hexagon.LibASM.PasswdHash.shellFound
 
     pop ecx
 
@@ -399,197 +283,6 @@ clearVariables:
     pop es
 
     ret
-
-;;************************************************************************************
-
-findUserPassword:
-
-    pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, su.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .fileNotFound
-
-    mov si, appFileBuffer    ;; Points to the buffer with the file contents
-    mov bx, word [positionBX] ;; Continue where the previous option left off
-
-    dec bx
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[positionBX], bx
-
-    cmp bx, searchSizeLimit
-
-    je .invalidPassword ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '|'
-    jne .searchBetweenDelimiters ;; The starting delimiter was found
-
-;; BX now points to the first character of the password retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, passwordObtained ;; The password will be copied to ES:DI
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.getUserPassword:
-
-    inc bx
-
-    cmp bx, 66
-    je .invalidPassword ;; If password greater than 66, it is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '&' ;; If another delimiter is found, the password has been loaded successfully
-    je .userPasswordObtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .getUserPassword
-
-.userPasswordObtained:
-
-    pop es
-
-    popa
-
-    ret
-
-.invalidPassword:
-
-    pop es
-
-    popa
-
-    stc
-
-    ret
-
-.fileNotFound:
-
-    pop es
-
-    popa
-
-    fputs su.fileNotFound
-
-    jmp finish
-
-;;************************************************************************************
-
-findShell:
-
-    pusha
-
-    push es
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov esi, su.file
-    mov edi, appFileBuffer
-
-    hx.syscall hx.open
-
-    jc .fileNotFound
-
-    mov si, appFileBuffer ;; Points to the buffer with the file contents
-    mov bx, word [positionBX] ;; Continue where the previous option left off
-
-    dec bx
-
-.searchBetweenDelimiters:
-
-    inc bx
-
-    mov word[positionBX], bx
-
-    cmp bx, searchSizeLimit
-
-    je .fileNotFound ;; If nothing is found within the size limit, cancel the search
-
-    mov al, [ds:si+bx]
-
-    cmp al, '&'
-    jne .searchBetweenDelimiters ;; The starting delimiter was found
-
-;; BX now points to the first character of the shell name retrieved from the file
-
-    push ds ;; User mode data segment (38h selector)
-    pop es
-
-    mov di, shellHexagonix ;; The shell name will be copied to ES:DI - shellHexagonix
-
-    mov si, appFileBuffer
-
-    add si, bx ;; Move SI to where BX points
-
-    mov bx, 0 ;; Start at 0
-
-.shellNameObtained:
-
-    inc bx
-
-    cmp bx, 13
-    je .invalidShellName ;; If file name greater than 11, the name is invalid
-
-    mov al, [ds:si+bx]
-
-    cmp al, '#' ;; If another delimiter is found, the name was loaded successfully
-    je .obtained
-
-;; If not ready, store the obtained character
-
-    stosb
-
-    jmp .shellNameObtained
-
-.obtained:
-
-    pop es
-
-    popa
-
-    ret
-
-.invalidShellName:
-
-    pop es
-
-    popa
-
-    jmp getDefaultShell
-
-
-.fileNotFound:
-
-    pop es
-
-    popa
-
-    jmp getDefaultShell
 
 ;;************************************************************************************
 
@@ -691,7 +384,7 @@ finish:
 ;;
 ;;************************************************************************************
 
-VERSION equ "1.9.0"
+VERSION equ "2.1.0"
 
 su:
 
@@ -714,14 +407,10 @@ db 10, "The requested user was not found: ", 0
 db "?", 0
 .helpParameter2:
 db "--help", 0
-.rootUser:
-db "root", 0
 .authenticationFailure:
 db 10, "su: authentication failed.", 0
 .defaultShell: ;; Name of the file containing the default Hexagonix shell
 db "sh", 0
-.file: ;; Login database filename
-db "passwd", 0
 
 ;; Buffers
 
@@ -730,17 +419,8 @@ times 17 db 0
 previousUser: ;; Previous User Buffer
 times 17 db 0
 shellHexagonix: ;; Stores the filename of the shell to be used by the system
-times 11 db 0
-user: ;; Username obtained from file
-times 15 db 0
-passwordObtained: ;; Password obtained from file
-times 64 db 0
+times 12 db 0
 
 previousCode:    dd 0 ;; Previous user code
 tryDefaultShell: db 0 ;; Signals an attempt to load the default shell
 parameters: db 0 ;; If the application received any parameters
-positionBX: dw 0
-
-;;************************************************************************************
-
-appFileBuffer: ;; Location where the configuration file will be opened

--- a/su/su.asm
+++ b/su/su.asm
@@ -70,7 +70,7 @@
 ;;
 ;;                            su utility for Hexagonix
 ;;
-;;                 Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                 Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                              All rights reserved.
 ;;
 ;;************************************************************************************

--- a/syslogd/syslogd.asm
+++ b/syslogd/syslogd.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/testa/testa.asm
+++ b/testa/testa.asm
@@ -1,3 +1,71 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
 ;; Temporary diagnostic app, not part of the distribution.
 ;; Calls hx.spawn on testb and confirms the caller keeps running immediately
 ;; afterward (proving spawn does not block), logging the returned PID/error.

--- a/testb/testb.asm
+++ b/testb/testb.asm
@@ -1,3 +1,71 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
 ;; Temporary diagnostic app, not part of the distribution.
 ;; Minimal child process: prints a message and exits immediately.
 ;; Used together with testa to isolate the process allocator's malloc/free

--- a/top/top.asm
+++ b/top/top.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without
@@ -73,7 +73,7 @@ use32
 include "HAPP.s" ;; Here is a structure for the HAPP header
 
 ;; Instance | Structure | Architecture | Version | Subversion | Entry Point | Image type
-appHeader headerHAPP HAPP.Architectures.i386, 1, 4, applicationStart, 01h
+appHeader headerHAPP HAPP.Architectures.i386, 1, 6, applicationStart, 01h
 
 ;;************************************************************************************
 
@@ -320,6 +320,9 @@ putStatus:
     cmp al, 4
     je .zombie
 
+    cmp al, 5
+    je .sleeping
+
     fputs top.statusUnknown
 
     ret
@@ -345,6 +348,12 @@ putStatus:
 .zombie:
 
     fputs top.statusZombie
+
+    ret
+
+.sleeping:
+
+    fputs top.statusSleeping
 
     ret
 
@@ -423,7 +432,7 @@ makeDescriptionBanner:
 
 ;;************************************************************************************
 
-VERSION equ "4.1.0"
+VERSION equ "4.2.0"
 
 top:
 
@@ -452,6 +461,8 @@ db "RUNNING", 0
 db "BLOCKED", 0
 .statusZombie:
 db "ZOMBIE", 0
+.statusSleeping:
+db "SLEEPING", 0
 .statusUnknown:
 db "UNKNOWN", 0
 .statusKernel:

--- a/top/top.asm
+++ b/top/top.asm
@@ -292,7 +292,7 @@ putSpace:
 
 ;;************************************************************************************
 
-;; Prints the status text for a process at a fixed column
+;; Prints the state text for a process at a fixed column
 ;;
 ;; Input:
 ;;
@@ -323,37 +323,46 @@ putStatus:
     cmp al, 5
     je .sleeping
 
-    fputs top.statusUnknown
+    cmp al, 6
+    je .idle
+
+    fputs top.stateUnknown
 
     ret
 
 .ready:
 
-    fputs top.statusReady
+    fputs top.stateReady
 
     ret
 
 .running:
 
-    fputs top.statusRunning
+    fputs top.stateRunning
 
     ret
 
 .blocked:
 
-    fputs top.statusBlocked
+    fputs top.stateBlocked
 
     ret
 
 .zombie:
 
-    fputs top.statusZombie
+    fputs top.stateZombie
 
     ret
 
 .sleeping:
 
-    fputs top.statusSleeping
+    fputs top.stateSleeping
+
+    ret
+
+.idle:
+
+    fputs top.stateIdle
 
     ret
 
@@ -387,7 +396,7 @@ putParent:
 
 .kernel:
 
-    fputs top.statusKernel
+    fputs top.stateKernel
 
     ret
 
@@ -432,7 +441,7 @@ makeDescriptionBanner:
 
 ;;************************************************************************************
 
-VERSION equ "4.2.0"
+VERSION equ "4.3.0"
 
 top:
 
@@ -453,19 +462,21 @@ db "All rights reserved.", 0
 db "?", 0
 .helpParameter2:
 db "--help", 0
-.statusReady:
+.stateReady:
 db "READY", 0
-.statusRunning:
+.stateRunning:
 db "RUNNING", 0
-.statusBlocked:
+.stateBlocked:
 db "BLOCKED", 0
-.statusZombie:
+.stateZombie:
 db "ZOMBIE", 0
-.statusSleeping:
+.stateSleeping:
 db "SLEEPING", 0
-.statusUnknown:
+.stateUnknown:
 db "UNKNOWN", 0
-.statusKernel:
+.stateIdle:
+db "IDLE", 0
+.stateKernel:
 db "KERNEL", 0
 .fontColor:       dd 0
 .backgroundColor: dd 0

--- a/uname/uname.asm
+++ b/uname/uname.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/whoami/whoami.asm
+++ b/whoami/whoami.asm
@@ -13,7 +13,7 @@
 ;;
 ;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
 ;;
-;;                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 ;;                        Todos os direitos reservados - All rights reserved.
 ;;
 ;;*************************************************************************************************
@@ -36,7 +36,7 @@
 ;;
 ;; BSD 3-Clause License
 ;;
-;; Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 ;; All rights reserved.
 ;;
 ;; Redistribution and use in source and binary forms, with or without

--- a/workera/workera.asm
+++ b/workera/workera.asm
@@ -1,3 +1,71 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
 ;; Temporary diagnostic app, not part of the distribution.
 ;; Loops forever, logging a tick and sleeping briefly, used together with
 ;; workerb and launcher to prove the round-robin scheduler actually

--- a/workerb/workerb.asm
+++ b/workerb/workerb.asm
@@ -1,3 +1,71 @@
+;;*************************************************************************************************
+;;
+;; 88                                                                                88
+;; 88                                                                                ""
+;; 88
+;; 88,dPPPba,   ,adPPPba, 8b,     ,d8 ,adPPPPba,  ,adPPPb,d8  ,adPPPba,  8b,dPPPba,  88 8b,     ,d8
+;; 88P'    "88 a8P     88  `P8, ,8P'  ""     `P8 a8"    `P88 a8"     "8a 88P'   `"88 88  `P8, ,8P'
+;; 88       88 8PP"""""""    )888(    ,adPPPPP88 8b       88 8b       d8 88       88 88    )888(
+;; 88       88 "8b,   ,aa  ,d8" "8b,  88,    ,88 "8a,   ,d88 "8a,   ,a8" 88       88 88  ,d8" "8b,
+;; 88       88  `"Pbbd8"' 8P'     `P8 `"8bbdP"P8  `"PbbdP"P8  `"PbbdP"'  88       88 88 8P'     `P8
+;;                                               aa,    ,88
+;;                                                "P8bbdP"
+;;
+;;                     Sistema Operacional Hexagonix - Hexagonix Operating System
+;;
+;;                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
+;;                        Todos os direitos reservados - All rights reserved.
+;;
+;;*************************************************************************************************
+;;
+;; Português:
+;;
+;; O Hexagonix e seus componentes são licenciados sob licença BSD-3-Clause. Leia abaixo
+;; a licença que governa este arquivo e verifique a licença de cada repositório para
+;; obter mais informações sobre seus direitos e obrigações ao utilizar e reutilizar
+;; o código deste ou de outros arquivos.
+;;
+;; English:
+;;
+;; Hexagonix and its components are licensed under a BSD-3-Clause license. Read below
+;; the license that governs this file and check each repository's license for
+;; obtain more information about your rights and obligations when using and reusing
+;; the code of this or other files.
+;;
+;;*************************************************************************************************
+;;
+;; BSD 3-Clause License
+;;
+;; Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
+;; All rights reserved.
+;;
+;; Redistribution and use in source and binary forms, with or without
+;; modification, are permitted provided that the following conditions are met:
+;;
+;; 1. Redistributions of source code must retain the above copyright notice, this
+;;    list of conditions and the following disclaimer.
+;;
+;; 2. Redistributions in binary form must reproduce the above copyright notice,
+;;    this list of conditions and the following disclaimer in the documentation
+;;    and/or other materials provided with the distribution.
+;;
+;; 3. Neither the name of the copyright holder nor the names of its
+;;    contributors may be used to endorse or promote products derived from
+;;    this software without specific prior written permission.
+;;
+;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+;; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+;; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+;; FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+;; SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+;; CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+;; OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;
+;; $HexagonixOS$
+
 ;; Temporary diagnostic app, not part of the distribution.
 ;; Loops forever, logging a tick and sleeping briefly, used together with
 ;; workera and launcher to prove the round-robin scheduler actually


### PR DESCRIPTION
- New adduser, deluser and passwd utilities to manage /shadow entries;
- su and login now read /shadow through Hexagon.LibASM.PasswdHash instead of the old /passwd file;
- login: fixes a username enumeration leak, a nonexistent username now always shows the password prompt like a real one, and only fails after Enter;
- ps/top: support the new IDLE and SLEEPING process states;
- ls: removes a duplicate filename print in each file type branch;
- New testa/testb and workera/workerb sample apps, demonstrating non blocking spawn and sleeping worker processes
- man: minor formatting update;
- Copyright year and version bumps.